### PR TITLE
Protobuffer and misc improvements

### DIFF
--- a/HyperionScreenCap/DXCapture.cs
+++ b/HyperionScreenCap/DXCapture.cs
@@ -5,55 +5,57 @@ using SlimDX.Windows;
 
 namespace HyperionScreenCap
 {
-    public class DxScreenCapture
+  public class DxScreenCapture
+  {
+    private readonly Device _d;
+
+    public DxScreenCapture(int monitorIndex)
     {
-        private readonly Device _d;
-
-        public DxScreenCapture()
+      try
+      {
+        var presentParams = new PresentParameters
         {
-            try
-            {
-                var presentParams = new PresentParameters
-                {
-                    Windowed = true,
-                    SwapEffect = SwapEffect.Discard
-                };
+          Windowed = true,
+          SwapEffect = SwapEffect.Discard,
+          PresentationInterval = PresentInterval.Immediate
+        };
 
-                _d = new Device(new Direct3D(), GetMonitor(Form1.MonitorIndex), DeviceType.Hardware, IntPtr.Zero, CreateFlags.SoftwareVertexProcessing, presentParams);
-            }
-            catch (Exception ex)
-            {
-                Notifications.Error(ex.Message);
-            }
-            
-        }
+        _d = new Device(new Direct3D(), GetMonitor(monitorIndex), DeviceType.Hardware, IntPtr.Zero,
+          CreateFlags.SoftwareVertexProcessing, presentParams);
+      }
+      catch (Exception){
+      }
 
-        public Surface CaptureScreen()
-        {
-            try
-            {
-                var s = Surface.CreateOffscreenPlain(_d, Screen.PrimaryScreen.Bounds.Width, Screen.PrimaryScreen.Bounds.Height, Format.A8R8G8B8, Pool.Scratch);
-                var b = Surface.CreateOffscreenPlain(_d, (Form1.HyperionWidth), (Form1.HyperionHeight), Format.A8R8G8B8, Pool.Scratch);
-                _d.GetFrontBufferData(0, s);
-                Surface.FromSurface(b, s, Filter.Triangle, 0);
-                s.Dispose();
-                return b;
-            }
-            catch (Exception ex)
-            {
-                Notifications.Error(ex.Message);
-            }
-            return null;
-        }
-
-        private static int GetMonitor(int monitorIndex)
-        {
-            var monitorArray = DisplayMonitor.EnumerateMonitors();
-            if ((monitorArray.Length -1) >= monitorIndex)
-            {
-                return (monitorArray[monitorIndex] != null) ? monitorIndex : 0;
-            }
-            return 0;
-        }
     }
+
+    public Surface CaptureScreen(int width, int height)
+    {
+      try
+      {
+        var s = Surface.CreateOffscreenPlain(_d, Screen.PrimaryScreen.Bounds.Width, Screen.PrimaryScreen.Bounds.Height,
+          Format.A8R8G8B8, Pool.Scratch);
+        var b = Surface.CreateOffscreenPlain(_d, (Form1.HyperionWidth), (Form1.HyperionHeight), Format.A8R8G8B8,
+          Pool.Scratch);
+        _d.GetFrontBufferData(0, s);
+        Surface.FromSurface(b, s, Filter.Triangle, 0);
+        s.Dispose();
+        return b;
+      }
+      catch (Exception ex)
+      {
+        Notifications.Error(ex.Message);
+      }
+      return null;
+    }
+
+    private static int GetMonitor(int monitorIndex)
+    {
+      var monitorArray = DisplayMonitor.EnumerateMonitors();
+      if ((monitorArray.Length - 1) >= monitorIndex)
+      {
+        return (monitorArray[monitorIndex] != null) ? monitorIndex : 0;
+      }
+      return 0;
+    }
+  }
 }

--- a/HyperionScreenCap/Form1.Designer.cs
+++ b/HyperionScreenCap/Form1.Designer.cs
@@ -33,7 +33,6 @@ namespace HyperionScreenCap
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.screenCaptureInterval = new System.Windows.Forms.Timer(this.components);
             this.SuspendLayout();
             // 
             // Form1
@@ -48,7 +47,5 @@ namespace HyperionScreenCap
         }
 
         #endregion
-
-        public Timer screenCaptureInterval;
     }
 }

--- a/HyperionScreenCap/Form1.Designer.cs
+++ b/HyperionScreenCap/Form1.Designer.cs
@@ -19,7 +19,6 @@ namespace HyperionScreenCap
             if (disposing && (components != null))
             {
                 TrayIcon.Dispose();
-                CloseConnection();
                 components.Dispose();
             }
             base.Dispose(disposing);
@@ -36,11 +35,6 @@ namespace HyperionScreenCap
             this.components = new System.ComponentModel.Container();
             this.screenCaptureInterval = new System.Windows.Forms.Timer(this.components);
             this.SuspendLayout();
-            // 
-            // screenCaptureInterval
-            // 
-            this.screenCaptureInterval.Interval = 1000;
-            this.screenCaptureInterval.Tick += new System.EventHandler(this.screenCaptureInterval_Tick);
             // 
             // Form1
             // 

--- a/HyperionScreenCap/Form1.cs
+++ b/HyperionScreenCap/Form1.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
-using System.Net.Sockets;
 using System.Threading;
 using System.Windows.Forms;
 using SlimDX;

--- a/HyperionScreenCap/Form1.cs
+++ b/HyperionScreenCap/Form1.cs
@@ -86,10 +86,11 @@ namespace HyperionScreenCap
     private void TrayIcon_DoubleClick
       (object sender, EventArgs e)
     {
-      if (screenCaptureInterval.Enabled)
+      if (CaptureEnabled)
       {
         TrayIcon.Icon = Resources.Hyperion_disabled;
         TrayIcon.Text = @"Hyperion Screen Capture (Disabled)";
+        _protoClient.ClearPriority(HyperionMessagePriority);
         CaptureEnabled = false;
       }
       else

--- a/HyperionScreenCap/Form1.cs
+++ b/HyperionScreenCap/Form1.cs
@@ -168,6 +168,9 @@ namespace HyperionScreenCap
 
             Thread.Sleep(CaptureInterval);
           }
+
+          ds.Dispose();
+          s.Dispose();
         }
       }
       catch (Exception ex)

--- a/HyperionScreenCap/HyperionScreenCap.csproj
+++ b/HyperionScreenCap/HyperionScreenCap.csproj
@@ -80,10 +80,6 @@
     <Reference Include="Google.ProtocolBuffers.Serialization">
       <HintPath>Libraries\Google.ProtocolBuffers.Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
       <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
       <Private>True</Private>
@@ -92,7 +88,6 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/HyperionScreenCap/Notifications.cs
+++ b/HyperionScreenCap/Notifications.cs
@@ -9,7 +9,6 @@ namespace HyperionScreenCap
         {
             Form1.TrayIcon.ShowBalloonTip(3000, "", errorMsg, ToolTipIcon.Error);
             //Stop the timer if anything goes wrong
-            Program.DisableTimer();
         }
 
         public static void Info(string infoMsg)

--- a/HyperionScreenCap/Program.cs
+++ b/HyperionScreenCap/Program.cs
@@ -1,29 +1,48 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows.Forms;
 
 namespace HyperionScreenCap
 {
-    internal static class Program
+  internal static class Program
+  {
+    private static Form1 _mainForm;
+
+    /// <summary>
+    /// The main entry point for the application.
+    /// </summary>
+    [STAThread]
+    private static void Main()
     {
-        private static Form1 _mainForm;
 
-        /// <summary>
-        /// The main entry point for the application.
-        /// </summary>
-        [STAThread]
-        private static void Main()
+
+      // Check if already running and exit if that's the case
+      if (isProgramRunning("hyperionscreencap", 0) > 1)
+      {
+        try
         {
-
-        _mainForm = new Form1();
-            Application.Run(_mainForm);
-            
+          MessageBox.Show("HyperionScreenCap is already running!");
+          Environment.Exit(0);
         }
-
-        public static void DisableTimer()
+        catch (Exception)
         {
-            _mainForm.screenCaptureInterval.Enabled = false;
         }
+      }
+      _mainForm = new Form1();
+      Application.Run(_mainForm);
 
-        
     }
+
+    private static int isProgramRunning(string name, int runtime)
+    {
+      foreach (var clsProcess in Process.GetProcesses())
+      {
+        if (clsProcess.ProcessName.ToLower().Equals(name))
+        {
+          runtime++;
+        }
+      }
+      return runtime;
+    }
+  }
 }

--- a/HyperionScreenCap/ProtoClient.cs
+++ b/HyperionScreenCap/ProtoClient.cs
@@ -1,110 +1,189 @@
 ﻿using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Threading;
 using Google.ProtocolBuffers;
 using proto;
 
 namespace HyperionScreenCap
 {
-    internal static class ProtoClient
+  internal class ProtoClient
+  {
+    private static TcpClient _socket = new TcpClient();
+    private static Stream _stream;
+    private static int _hyperionPriority;
+    private static bool initLock;
+
+    public void Init(string hyperionIp = "10.1.2.83", int hyperionProtoPort = 19445, int priority = 10)
     {
-        private static TcpClient _socket = new TcpClient();
-        private static Stream _stream;
-        private static int _hyperionPriority;
-
-        public static void Init(string hyperionIp = "10.1.2.83", int hyperionProtoPort = 19445, int priority = 10)
+      try
+      {
+        if (_socket.Connected || initLock) return;
+        initLock = true;
+        _hyperionPriority = priority;
+        _socket = new TcpClient
         {
-            if (_socket.Connected) return;
-            Logger("Connecting to Hyperion...");
-            _hyperionPriority = priority;
-            _socket = new TcpClient
-            {
-                SendTimeout = 5000,
-                ReceiveTimeout = 5000
-            };
-            _socket.Connect(hyperionIp, hyperionProtoPort);
-            _stream = _socket.GetStream();
-
-            Logger("Connected to Hyperion using protobufer!");
-        }
-
-        public static bool IsConnected()
-        {
-            try
-            {
-                if (_socket == null)
-                {
-                    return false;
-                }
-                if (_socket.Connected)
-                {
-                    return true;
-                }
-            }
-            catch (Exception e)
-            {
-                Logger("Error occured during isConnected: " + e.Message);
-            }
-
-            return false;
-        }
-
-        public static void SendImage(byte[] pixeldata)
-        {
-            try
-            {
-                var imageRequest = ImageRequest.CreateBuilder()
-                    .SetImagedata(ByteString.CopyFrom(pixeldata))
-                    .SetImageheight(Form1.HyperionHeight)
-                    .SetImagewidth(Form1.HyperionWidth)
-                    .SetPriority(_hyperionPriority)
-                    .SetDuration(Form1.HyperionMessageDuration)
-                    .Build();
-
-                var request = HyperionRequest.CreateBuilder()
-                    .SetCommand(HyperionRequest.Types.Command.IMAGE)
-                    .SetExtension(ImageRequest.ImageRequest_, imageRequest)
-                    .Build();
-
-                SendRequest(request);
-            }
-            catch (Exception e)
-            {
-                Logger("Error during send image to hyperion: " + e.Message);
-            }
-        }
-
-
-        private static void SendRequest(IMessageLite request)
-        {
-            try
-            {
-                if (!_socket.Connected) return;
-                var size = request.SerializedSize;
-                var header = new byte[4];
-                header[0] = (byte) ((size >> 24) & 0xFF);
-                header[1] = (byte) ((size >> 16) & 0xFF);
-                header[2] = (byte) ((size >> 8) & 0xFF);
-                header[3] = (byte) (size & 0xFF);
-
-                var headerSize = header.Length;
-                _stream.Write(header, 0, headerSize);
-                request.WriteTo(_stream);
-                _stream.Flush();
-
-                // Enable reply message if needed (debugging only)
-                //HyperionReply reply = ReceiveReply();
-                //Logger("Reply: " + reply.ToString());
-            }
-            catch (Exception e)
-            {
-                Logger("Error during send request to hyperion: " + e.Message);
-            }
-        }
-
-        private static void Logger(string message)
-        {
-            Notifications.Info(message);
-        }
+          SendTimeout = 5000,
+          ReceiveTimeout = 5000
+        };
+        _socket.Connect(hyperionIp, hyperionProtoPort);
+        _stream = _socket.GetStream();
+        initLock = false;
+      }
+      catch (Exception)
+      {
+        initLock = false;
+      }
     }
+
+    public bool IsConnected()
+    {
+      try
+      {
+        if (_socket == null)
+        {
+          return false;
+        }
+        if (_socket.Connected)
+        {
+          return true;
+        }
+      }
+      catch (Exception){
+      }
+
+      return false;
+    }
+
+
+    public void Disconnect()
+    {
+      _socket?.Close();
+    }
+
+    public void SendImage(byte[] pixeldataRaw)
+    {
+      MemoryStream stream = new MemoryStream(pixeldataRaw);
+      BinaryReader reader = new BinaryReader(stream);
+
+      stream.Position = 0; // ensure that what start at the beginning of the stream. 
+      reader.ReadBytes(14); // skip bitmap file info header
+      byte[] bmiInfoHeader = reader.ReadBytes(4 + 4 + 4 + 2 + 2 + 4 + 4 + 4 + 4 + 4 + 4);
+
+      int rgbL = (int)(stream.Length - stream.Position);
+      int rgb = (int)(rgbL / (64 * 64));
+
+      byte[] pixelData = reader.ReadBytes((int)(stream.Length - stream.Position));
+
+      byte[] h1pixelData = new byte[64 * rgb];
+      byte[] h2pixelData = new byte[64 * rgb];
+
+      // We need to flip the image horizontally.
+      // Because after reading the bytes into the bytearray with BinaryReader the image is upside down (bmp characteristic).
+      int i;
+      for (i = 0; i < ((64 / 2) - 1); i++)
+      {
+        Array.Copy(pixelData, i * 64 * rgb, h1pixelData, 0, 64 * rgb);
+        Array.Copy(pixelData, (64 - i - 1) * 64 * rgb, h2pixelData, 0, 64 * rgb);
+        Array.Copy(h1pixelData, 0, pixelData, (64 - i - 1) * 64 * rgb, 64 * rgb);
+        Array.Copy(h2pixelData, 0, pixelData, i * 64 * rgb, 64 * rgb);
+      }
+
+      try
+      {
+        // Hyperion expects the bytestring to be the size of 3*width*height.
+        // So 3 bytes per pixel, as in RGB.
+        // Given pixeldata however is 4 bytes per pixel, as in RGBA.
+        // So we need to remove the last byte per pixel.
+        byte[] newpixeldata = new byte[64 * 64 * 3];
+        int x = 0;
+        int i2 = 0;
+        while (i2 <= (newpixeldata.GetLength(0) - 2))
+        {
+          newpixeldata[i2] = pixelData[i2 + x + 2];
+          newpixeldata[i2 + 1] = pixelData[i2 + x + 1];
+          newpixeldata[i2 + 2] = pixelData[i2 + x];
+          i2 += 3;
+          x++;
+        }
+
+        SendImageToServer(newpixeldata);
+      }
+      catch (Exception){
+      }
+    }
+    public void SendImageToServer(byte[] pixeldata)
+    {
+      try
+      {
+        var imageRequest = ImageRequest.CreateBuilder()
+          .SetImagedata(ByteString.CopyFrom(pixeldata))
+          .SetImageheight(Form1.HyperionHeight)
+          .SetImagewidth(Form1.HyperionWidth)
+          .SetPriority(_hyperionPriority)
+          .SetDuration(Form1.HyperionMessageDuration)
+          .Build();
+
+        var request = HyperionRequest.CreateBuilder()
+          .SetCommand(HyperionRequest.Types.Command.IMAGE)
+          .SetExtension(ImageRequest.ImageRequest_, imageRequest)
+          .Build();
+
+        SendRequest(request);
+      }
+      catch (Exception){
+      }
+    }
+
+
+    public void ClearPriority(int priority)
+    {
+      try
+      {
+        if (!IsConnected())
+        {
+          return;
+        }
+
+        ClearRequest clearRequest = ClearRequest.CreateBuilder()
+          .SetPriority(priority)
+          .Build();
+
+        HyperionRequest request = HyperionRequest.CreateBuilder()
+          .SetCommand(HyperionRequest.Types.Command.CLEAR)
+          .SetExtension(ClearRequest.ClearRequest_, clearRequest)
+          .Build();
+
+        SendRequest(request);
+      }
+      catch (Exception){
+      }
+    }
+
+
+    private static void SendRequest(IMessageLite request)
+    {
+      try
+      {
+        if (!_socket.Connected) return;
+        var size = request.SerializedSize;
+        var header = new byte[4];
+        header[0] = (byte) ((size >> 24) & 0xFF);
+        header[1] = (byte) ((size >> 16) & 0xFF);
+        header[2] = (byte) ((size >> 8) & 0xFF);
+        header[3] = (byte) (size & 0xFF);
+
+        var headerSize = header.Length;
+        _stream.Write(header, 0, headerSize);
+        request.WriteTo(_stream);
+        _stream.Flush();
+
+        // Enable reply message if needed (debugging only)
+        //HyperionReply reply = ReceiveReply();
+        //Logger("Reply: " + reply.ToString());
+      }
+      catch (Exception){
+      }
+    }
+  }
 }

--- a/HyperionScreenCap/app.config
+++ b/HyperionScreenCap/app.config
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="hyperionServerIP" value="192.168.1.171"/>
-    <add key="hyperionServerJsonPort" value="19444"/>
-    <add key="hyperionServerProtoPort" value="19445"/>
-    <add key="protocol" value="proto"/> <!-- Which Hyperion protocol to use (json / proto) -->
+    <add key="hyperionServerIP" value="10.1.2.83"/>
+    <add key="hyperionServerPort" value="19445"/>
     <add key="hyperionMessagePriority" value="10"/> <!-- Lower number means higher priority -->
     <add key="hyperionMessageDuration" value="1000"/> <!-- How long will each captured screenshot stay on LEDs -->
-    <add key="width" value="114"/> <!-- Keep these values small -->
+    <add key="width"  value="64"/> <!-- Keep these values small -->
     <add key="height" value="64"/> <!-- Keep these values small -->
-    <add key="captureInterval" value="50"/>
-    <add key="notificationLevel" value="info"/>
+    <add key="captureInterval" value="0"/>
+    <add key="notificationLevel" value="Info"/>
     <add key="monitorIndex" value="0"/> <!-- 0 is the main monitor -->
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup>

--- a/HyperionScreenCap/app.config
+++ b/HyperionScreenCap/app.config
@@ -7,7 +7,7 @@
     <add key="hyperionMessageDuration" value="1000"/> <!-- How long will each captured screenshot stay on LEDs -->
     <add key="width"  value="64"/> <!-- Keep these values small -->
     <add key="height" value="64"/> <!-- Keep these values small -->
-    <add key="captureInterval" value="0"/>
+    <add key="captureInterval" value="5"/>
     <add key="notificationLevel" value="Info"/>
     <add key="monitorIndex" value="0"/> <!-- 0 is the main monitor -->
   </appSettings>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Windows screen capture program for the [Hyperion](https://github.com/tvdzwan/hyp
 The program uses Direct3D9 to capture the screen, resize it and send it to the ProtoBuffer interface of Hyperion.
 
 ## Download
-[HyperionScreenCap.zip](https://github.com/RickDB/HyperionScreenCap/releases/download/V1.2/HyperionScreenCap.zip)
+[HyperionScreenCap.zip](https://github.com/RickDB/HyperionScreenCap/releases/download/V1.3/HyperionScreenCap.zip)
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Windows screen capture program for the [Hyperion](https://github.com/tvdzwan/hyp
 The program uses Direct3D9 to capture the screen, resize it and send it to the ProtoBuffer interface of Hyperion.
 
 ## Download
-Portable zip: [HyperionScreenCap.zip](https://github.com/RickDB/HyperionScreenCap/releases/download/v1.2/HyperionScreenCap.zip)
+[HyperionScreenCap.zip](https://github.com/RickDB/HyperionScreenCap/releases/download/V1.2/HyperionScreenCap.zip)
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setup is done by modifying the HyperionScreenCap.exe.config file.
     <add key="hyperionMessageDuration" value="1000"/> <!-- How long will each captured screenshot stay on LEDs -->
     <add key="width"  value="64"/> <!-- Keep these values small -->
     <add key="height" value="64"/> <!-- Keep these values small -->
-    <add key="captureInterval" value="10"/>
+    <add key="captureInterval" value="60"/>
     <add key="notificationLevel" value="None"/>
     <add key="monitorIndex" value="0"/> <!-- 0 is the main monitor -->
   </appSettings>

--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 Windows screen capture program for the [Hyperion](https://github.com/tvdzwan/hyperion) open-source Ambilight project.
 
-The program uses Direct3D9 to capture the screen, resize it and send it to the Proto/JSON interface of Hyperion.
+The program uses Direct3D9 to capture the screen, resize it and send it to the ProtoBuffer interface of Hyperion.
 
 ## Download
-Portable zip: [HyperionScreenCap.zip](https://github.com/djhansel/HyperionScreenCap/releases/download/v1.2/HyperionScreenCap.zip)
-
-Installer (auto installs dependencies): [SetupHyperionScreenCap.exe](https://github.com/djhansel/HyperionScreenCap/releases/download/v1.2/SetupHyperionScreenCap.exe)
+Portable zip: [HyperionScreenCap.zip](https://github.com/RickDB/HyperionScreenCap/releases/download/v1.2/HyperionScreenCap.zip)
 
 ## Dependencies
 
@@ -28,19 +26,16 @@ Setup is done by modifying the HyperionScreenCap.exe.config file.
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="hyperionServerIP" value="192.168.1.171"/>
-    <add key="hyperionServerJsonPort" value="19444"/>
-    <add key="hyperionServerProtoPort" value="19445"/>
-    <add key="protocol" value="proto"/> <!-- Which Hyperion protocol to use (json / proto) -->
+    <add key="hyperionServerIP" value="10.1.2.83"/>
+    <add key="hyperionServerPort" value="19445"/>
     <add key="hyperionMessagePriority" value="10"/> <!-- Lower number means higher priority -->
     <add key="hyperionMessageDuration" value="1000"/> <!-- How long will each captured screenshot stay on LEDs -->
-    <add key="width" value="114"/> <!-- Keep these values small -->
+    <add key="width"  value="64"/> <!-- Keep these values small -->
     <add key="height" value="64"/> <!-- Keep these values small -->
-    <add key="captureInterval" value="50"/>
-    <add key="notificationLevel" value="info"/>
+    <add key="captureInterval" value="10"/>
+    <add key="notificationLevel" value="None"/>
     <add key="monitorIndex" value="0"/> <!-- 0 is the main monitor -->
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup>
 </configuration>
-
 ```


### PR DESCRIPTION
- Removed JSON support, ProtoBuffer is now the default method to keep it simple and to follow Hyperion standards.
- Removed timer_tick solution for capture and replaced it with loop, capture interval is now no longer needed but can help with slower systems.
- Re-added missing parts of ProtoClient.
- Implemented reconnect support.
- Set DirectX PresentInterval to PresentInterval.Immediate.
- Cleaned up code.
